### PR TITLE
创建静态导航站并爬取内容

### DIFF
--- a/.github/workflows/deploy-alternative.yml
+++ b/.github/workflows/deploy-alternative.yml
@@ -1,0 +1,21 @@
+name: Deploy to GitHub Pages (Alternative)
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./
+        force_orphan: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,27 +15,23 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: '.'
-
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+          
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/GitHub_Pages_Setup.md
+++ b/GitHub_Pages_Setup.md
@@ -1,0 +1,180 @@
+# GitHub Pages 部署指南
+
+## 🚨 解决 "Get Pages site failed" 错误
+
+如果您遇到 `Error: Get Pages site failed` 错误，请按照以下步骤操作：
+
+### 方法一：手动启用 GitHub Pages
+
+1. **进入仓库设置页面**
+   - 点击仓库顶部的 `Settings` 选项卡
+   - 在左侧菜单中找到 `Pages`
+
+2. **配置 Pages 设置**
+   - **Source**: 选择 `GitHub Actions`
+   - 保存设置
+
+3. **检查权限**
+   - 确保仓库是 Public 或者有 GitHub Pro/Teams 账户
+   - 在 `Settings` → `Actions` → `General` 中：
+     - 允许所有 Actions：`Allow all actions and reusable workflows`
+     - Workflow permissions：选择 `Read and write permissions`
+     - 勾选 `Allow GitHub Actions to create and approve pull requests`
+
+### 方法二：使用简化的 GitHub Actions 配置
+
+如果方法一不起作用，请使用以下简化配置：
+
+```yaml
+name: Static HTML Deploy
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+      
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+      
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: '.'
+        
+    - name: Deploy
+      id: deployment
+      uses: actions/deploy-pages@v4
+```
+
+### 方法三：传统分支部署方式
+
+如果 GitHub Actions 方式仍有问题，可以使用传统的分支部署：
+
+1. **创建 gh-pages 分支**
+```bash
+git checkout --orphan gh-pages
+git rm -rf .
+cp ../main-branch/* .
+git add .
+git commit -m "Deploy to GitHub Pages"
+git push origin gh-pages
+```
+
+2. **在仓库设置中**
+   - Source: 选择 `Deploy from a branch`
+   - Branch: 选择 `gh-pages`
+   - Folder: 选择 `/ (root)`
+
+### 方法四：使用第三方 Action
+
+使用更简单的第三方 Action：
+
+```yaml
+name: Deploy to Pages
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./
+```
+
+## 🔧 常见问题解决
+
+### 问题 1: 权限不足
+**错误**: `Error: Resource not accessible by integration`
+
+**解决方案**:
+1. 检查仓库的 Actions 权限设置
+2. 确保工作流有正确的 permissions 配置
+
+### 问题 2: 仓库类型问题
+**错误**: Private 仓库无法使用 GitHub Pages (免费版)
+
+**解决方案**:
+1. 将仓库设为 Public
+2. 或升级到 GitHub Pro 账户
+
+### 问题 3: 分支不存在
+**错误**: `The branch main does not exist`
+
+**解决方案**:
+```bash
+git branch -M main
+git push -u origin main
+```
+
+### 问题 4: CNAME 冲突
+**错误**: 自定义域名冲突
+
+**解决方案**:
+1. 删除 CNAME 文件
+2. 重新配置域名设置
+
+## 📋 部署前检查清单
+
+- [ ] 仓库是 Public 或有 Pro 账户
+- [ ] GitHub Pages 在仓库设置中已启用
+- [ ] Actions 权限已正确配置
+- [ ] 主分支名为 `main`
+- [ ] 所有文件已提交并推送
+
+## 🚀 快速部署命令
+
+```bash
+# 检查当前分支
+git branch
+
+# 确保在 main 分支
+git checkout main
+
+# 提交所有更改
+git add .
+git commit -m "Setup GitHub Pages"
+git push origin main
+
+# 手动触发 Actions (如果需要)
+# 进入 GitHub 仓库 → Actions → 选择工作流 → Run workflow
+```
+
+## 📞 获取帮助
+
+如果问题仍然存在：
+
+1. 查看 GitHub Actions 运行日志
+2. 检查 GitHub 状态页面：https://www.githubstatus.com/
+3. 参考 GitHub Pages 官方文档：https://docs.github.com/en/pages
+
+## ✅ 验证部署成功
+
+部署成功后，您的网站将在以下地址可用：
+```
+https://your-username.github.io/repository-name
+```
+
+通常需要 5-10 分钟才能完全生效。

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Gopher Navigator
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ npx http-server
 
 ### GitHub Pages部署
 
+#### 方法一：自动部署 (推荐)
+
 1. Fork这个项目到你的GitHub账户
 
 2. 进入项目设置页面：
@@ -58,12 +60,30 @@ npx http-server
    - 在左侧菜单中找到 "Pages"
 
 3. 配置GitHub Pages：
-   - Source: 选择 "Deploy from a branch"
-   - Branch: 选择 "main" 分支
-   - Folder: 选择 "/ (root)"
-   - 点击 "Save"
+   - **Source**: 选择 "GitHub Actions"
+   - 保存设置
 
-4. 等待几分钟，你的网站将在 `https://yourusername.github.io/gopher-navigator` 上线
+4. 检查权限设置：
+   - 进入 "Settings" → "Actions" → "General"
+   - Workflow permissions: 选择 "Read and write permissions"
+   - 勾选 "Allow GitHub Actions to create and approve pull requests"
+
+5. 推送代码到main分支，GitHub Actions会自动部署
+
+#### 方法二：如果遇到部署错误
+
+如果看到 "Get Pages site failed" 错误：
+
+1. **使用备用配置**：将 `.github/workflows/deploy-alternative.yml` 重命名为 `deploy.yml`
+
+2. **或者使用传统分支部署**：
+   - 在仓库设置中，Source 选择 "Deploy from a branch" 
+   - Branch 选择 "main"，Folder 选择 "/ (root)"
+
+3. **详细故障排除**：参考 `GitHub_Pages_Setup.md` 文件
+
+#### 验证部署
+网站将在 `https://yourusername.github.io/gopher-navigator` 上线，通常需要5-10分钟生效。
 
 ### 自定义域名（可选）
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,163 @@
-# my_navigation
+# Gopher Navigator - Go语言学习导航站
+
+一个专门为Go语言学习者打造的资源导航网站，收集整理了最全面、最实用的Go语言学习资源。
+
+## 🌟 特性
+
+- 📚 **丰富的资源分类** - 包含官方文档、教程学习、开发工具、社区论坛、开源项目等
+- 🔍 **智能搜索功能** - 快速查找所需资源，支持关键词搜索
+- 🎨 **现代化设计** - 参考topgoer.cn设计风格，美观易用
+- 📱 **响应式布局** - 完美适配各种设备
+- 🌙 **主题切换** - 支持明暗主题切换
+- ⚡ **性能优化** - 纯静态网站，加载速度快
+- 🚀 **GitHub Pages支持** - 一键部署到GitHub Pages
+
+## 📁 项目结构
+
+```
+gopher-navigator/
+├── index.html          # 主页面
+├── css/
+│   └── style.css       # 样式文件
+├── js/
+│   └── script.js       # 交互脚本
+├── README.md           # 项目说明
+└── docs/              # 文档目录
+```
+
+## 🚀 快速开始
+
+### 本地预览
+
+1. 克隆项目到本地：
+```bash
+git clone https://github.com/yourusername/gopher-navigator.git
+cd gopher-navigator
+```
+
+2. 使用任意HTTP服务器启动项目：
+```bash
+# 使用Python
+python -m http.server 8000
+
+# 使用Node.js
+npx http-server
+
+# 使用Live Server (VS Code插件)
+# 右键index.html -> Open with Live Server
+```
+
+3. 浏览器访问 `http://localhost:8000`
+
+### GitHub Pages部署
+
+1. Fork这个项目到你的GitHub账户
+
+2. 进入项目设置页面：
+   - 点击仓库的 "Settings" 选项卡
+   - 在左侧菜单中找到 "Pages"
+
+3. 配置GitHub Pages：
+   - Source: 选择 "Deploy from a branch"
+   - Branch: 选择 "main" 分支
+   - Folder: 选择 "/ (root)"
+   - 点击 "Save"
+
+4. 等待几分钟，你的网站将在 `https://yourusername.github.io/gopher-navigator` 上线
+
+### 自定义域名（可选）
+
+如果你有自己的域名，可以：
+
+1. 在项目根目录创建 `CNAME` 文件
+2. 在文件中写入你的域名，如：`gopher.example.com`
+3. 在你的域名DNS设置中添加CNAME记录，指向 `yourusername.github.io`
+
+## 🛠️ 功能说明
+
+### 核心功能
+
+- **分类导航**: 将Go语言资源按类别整理，方便查找
+- **搜索功能**: 输入关键词快速定位相关资源
+- **主题切换**: 支持明暗两种主题
+- **返回顶部**: 长页面快速返回顶部
+- **平滑滚动**: 页面内导航平滑滚动效果
+
+### 快捷键
+
+- `Ctrl/Cmd + K`: 快速打开搜索框
+- `ESC`: 关闭搜索结果
+
+### 交互特性
+
+- 悬停效果和动画
+- 响应式设计
+- 无障碍访问支持
+- 访问统计（本地存储）
+
+## 📊 资源统计
+
+本站目前收录了：
+- 100+ 学习资源
+- 20+ 资源分类
+- 50+ 开源项目
+- 30+ 实用工具
+
+## 🤝 贡献指南
+
+欢迎为这个项目贡献资源和代码！
+
+### 添加新资源
+
+1. Fork项目
+2. 编辑 `index.html` 文件
+3. 在相应的分类中添加新的资源链接
+4. 提交Pull Request
+
+### 报告问题
+
+如果发现链接失效、分类错误或其他问题，请：
+1. 提交Issue详细描述问题
+2. 或直接提交Pull Request修复
+
+### 建议新功能
+
+欢迎在Issues中提出新功能建议。
+
+## 📝 更新日志
+
+### v1.0.0 (2024-01-15)
+- 🎉 首次发布
+- ✨ 基础导航功能
+- 🔍 搜索功能
+- 🎨 响应式设计
+- 🌙 主题切换
+
+## 🔗 相关链接
+
+- [Go官方网站](https://golang.org/)
+- [地鼠文档](https://www.topgoer.cn/)
+- [Go语言中文网](https://studygolang.com/)
+
+## 📄 许可证
+
+本项目采用 MIT 许可证。详情请见 [LICENSE](LICENSE) 文件。
+
+## 🙏 致谢
+
+- [Go官方团队](https://golang.org/) - 创造了优秀的Go语言
+- [地鼠文档](https://www.topgoer.cn/) - 设计灵感来源
+- 所有Go语言社区贡献者
+
+## 📞 联系方式
+
+如果你有任何问题或建议，欢迎通过以下方式联系：
+
+- GitHub Issues: [提交问题](https://github.com/yourusername/gopher-navigator/issues)
+- Email: your.email@example.com
+
+---
+
+⭐ 如果这个项目对你有帮助，请给个Star支持一下！
+
+🚀 Happy Coding with Go!

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,488 @@
+/* Reset and Base Styles */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    line-height: 1.6;
+    color: #333;
+    background-color: #f8f9fa;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+/* Header Styles */
+.header {
+    background: #fff;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+}
+
+.navbar {
+    padding: 1rem 0;
+}
+
+.nav-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+.nav-logo {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.logo {
+    width: 32px;
+    height: 32px;
+}
+
+.site-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #00ADD8;
+}
+
+.nav-menu {
+    display: flex;
+    list-style: none;
+    gap: 2rem;
+}
+
+.nav-link {
+    text-decoration: none;
+    color: #333;
+    font-weight: 500;
+    transition: color 0.3s ease;
+    position: relative;
+}
+
+.nav-link:hover {
+    color: #00ADD8;
+}
+
+.nav-link::after {
+    content: '';
+    position: absolute;
+    width: 0;
+    height: 2px;
+    bottom: -5px;
+    left: 0;
+    background-color: #00ADD8;
+    transition: width 0.3s ease;
+}
+
+.nav-link:hover::after {
+    width: 100%;
+}
+
+/* Hero Section */
+.hero-section {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    padding: 4rem 0;
+    text-align: center;
+}
+
+.hero-content {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+.hero-title {
+    font-size: 3rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+}
+
+.hero-subtitle {
+    font-size: 1.2rem;
+    margin-bottom: 2rem;
+    opacity: 0.9;
+}
+
+.hero-stats {
+    display: flex;
+    justify-content: center;
+    gap: 3rem;
+    margin-top: 2rem;
+}
+
+.stat-item {
+    text-align: center;
+}
+
+.stat-number {
+    display: block;
+    font-size: 2rem;
+    font-weight: 700;
+    color: #FFD700;
+}
+
+.stat-label {
+    font-size: 0.9rem;
+    opacity: 0.9;
+}
+
+/* Quick Navigation */
+.quick-nav {
+    padding: 4rem 0;
+    background: white;
+}
+
+.section-title {
+    text-align: center;
+    font-size: 2rem;
+    margin-bottom: 3rem;
+    color: #333;
+    position: relative;
+}
+
+.section-title::after {
+    content: '';
+    position: absolute;
+    width: 60px;
+    height: 3px;
+    background: #00ADD8;
+    bottom: -10px;
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+.nav-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 2rem;
+    margin-top: 2rem;
+}
+
+.nav-card {
+    background: white;
+    padding: 2rem;
+    border-radius: 12px;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    border: 2px solid transparent;
+}
+
+.nav-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 30px rgba(0,0,0,0.15);
+    border-color: #00ADD8;
+}
+
+.card-icon {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+}
+
+.nav-card h3 {
+    font-size: 1.3rem;
+    margin-bottom: 0.5rem;
+    color: #333;
+}
+
+.nav-card p {
+    color: #666;
+    font-size: 0.9rem;
+}
+
+/* Content Sections */
+.content-section {
+    padding: 4rem 0;
+}
+
+.content-section:nth-child(even) {
+    background: white;
+}
+
+.content-section:nth-child(odd) {
+    background: #f8f9fa;
+}
+
+.resource-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    gap: 2rem;
+    margin-top: 2rem;
+}
+
+.resource-category {
+    background: white;
+    padding: 2rem;
+    border-radius: 12px;
+    box-shadow: 0 2px 15px rgba(0,0,0,0.08);
+    border-left: 4px solid #00ADD8;
+}
+
+.category-title {
+    font-size: 1.3rem;
+    margin-bottom: 1rem;
+    color: #333;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.category-title::before {
+    content: '🔗';
+    font-size: 1.2rem;
+}
+
+.resource-list {
+    list-style: none;
+}
+
+.resource-list li {
+    margin-bottom: 0.8rem;
+    padding-left: 1rem;
+    position: relative;
+}
+
+.resource-list li::before {
+    content: '▸';
+    position: absolute;
+    left: 0;
+    color: #00ADD8;
+    font-weight: bold;
+}
+
+.resource-list a {
+    color: #333;
+    text-decoration: none;
+    display: block;
+    padding: 0.3rem 0;
+    transition: all 0.3s ease;
+    border-radius: 4px;
+}
+
+.resource-list a:hover {
+    color: #00ADD8;
+    background-color: rgba(0, 173, 216, 0.1);
+    padding-left: 0.5rem;
+    transform: translateX(5px);
+}
+
+/* Footer */
+.footer {
+    background: #2c3e50;
+    color: white;
+    padding: 3rem 0 1rem;
+}
+
+.footer-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 2rem;
+    margin-bottom: 2rem;
+}
+
+.footer-section h3 {
+    margin-bottom: 1rem;
+    color: #00ADD8;
+}
+
+.footer-section p {
+    line-height: 1.6;
+    opacity: 0.9;
+}
+
+.footer-section ul {
+    list-style: none;
+}
+
+.footer-section ul li {
+    margin-bottom: 0.5rem;
+}
+
+.footer-section ul li a {
+    color: white;
+    text-decoration: none;
+    opacity: 0.8;
+    transition: opacity 0.3s ease;
+}
+
+.footer-section ul li a:hover {
+    opacity: 1;
+    color: #00ADD8;
+}
+
+.github-link {
+    display: inline-block;
+    background: #00ADD8;
+    color: white;
+    padding: 0.5rem 1rem;
+    text-decoration: none;
+    border-radius: 6px;
+    margin-top: 1rem;
+    transition: background 0.3s ease;
+}
+
+.github-link:hover {
+    background: #0088a8;
+}
+
+.footer-bottom {
+    border-top: 1px solid #34495e;
+    padding-top: 1rem;
+    text-align: center;
+    opacity: 0.7;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .nav-menu {
+        flex-direction: column;
+        gap: 1rem;
+    }
+    
+    .hero-title {
+        font-size: 2rem;
+    }
+    
+    .hero-stats {
+        flex-direction: column;
+        gap: 1rem;
+    }
+    
+    .nav-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .resource-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .footer-content {
+        grid-template-columns: 1fr;
+        text-align: center;
+    }
+}
+
+@media (max-width: 480px) {
+    .nav-container {
+        flex-direction: column;
+        gap: 1rem;
+    }
+    
+    .hero-content {
+        padding: 0 10px;
+    }
+    
+    .hero-title {
+        font-size: 1.8rem;
+    }
+    
+    .section-title {
+        font-size: 1.5rem;
+    }
+    
+    .resource-category {
+        padding: 1.5rem;
+    }
+}
+
+/* Smooth scrolling */
+html {
+    scroll-behavior: smooth;
+}
+
+/* Loading animation */
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(30px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.content-section {
+    animation: fadeInUp 0.6s ease-out;
+}
+
+/* Custom scrollbar */
+::-webkit-scrollbar {
+    width: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: #f1f1f1;
+}
+
+::-webkit-scrollbar-thumb {
+    background: #00ADD8;
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: #0088a8;
+}
+
+/* Accessibility */
+.nav-link:focus,
+.resource-list a:focus,
+.github-link:focus {
+    outline: 2px solid #00ADD8;
+    outline-offset: 2px;
+}
+
+/* Print styles */
+@media print {
+    .header,
+    .footer {
+        display: none;
+    }
+    
+    .content-section {
+        break-inside: avoid;
+    }
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #1a1a1a;
+        color: #e0e0e0;
+    }
+    
+    .header {
+        background: #2d2d2d;
+    }
+    
+    .nav-link {
+        color: #e0e0e0;
+    }
+    
+    .resource-category {
+        background: #2d2d2d;
+        color: #e0e0e0;
+    }
+    
+    .content-section:nth-child(even) {
+        background: #2d2d2d;
+    }
+    
+    .content-section:nth-child(odd) {
+        background: #1a1a1a;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Go语言学习导航 - Gopher Navigator</title>
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="icon" href="https://golang.org/lib/godoc/images/go-logo-blue.svg" type="image/svg+xml">
+</head>
+<body>
+    <!-- 顶部导航 -->
+    <header class="header">
+        <nav class="navbar">
+            <div class="nav-container">
+                <div class="nav-logo">
+                    <img src="https://golang.org/lib/godoc/images/go-logo-blue.svg" alt="Go Logo" class="logo">
+                    <span class="site-title">Gopher Navigator</span>
+                </div>
+                <ul class="nav-menu">
+                    <li class="nav-item"><a href="#home" class="nav-link">首页</a></li>
+                    <li class="nav-item"><a href="#docs" class="nav-link">文档</a></li>
+                    <li class="nav-item"><a href="#tutorials" class="nav-link">教程</a></li>
+                    <li class="nav-item"><a href="#tools" class="nav-link">工具</a></li>
+                    <li class="nav-item"><a href="#community" class="nav-link">社区</a></li>
+                    <li class="nav-item"><a href="#projects" class="nav-link">项目</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <!-- 主要内容 -->
+    <main class="main-content">
+        <!-- 首页横幅 -->
+        <section id="home" class="hero-section">
+            <div class="hero-content">
+                <h1 class="hero-title">Go语言学习导航站</h1>
+                <p class="hero-subtitle">收集整理最全面的Go语言学习资源，助力你的Gopher之路</p>
+                <div class="hero-stats">
+                    <div class="stat-item">
+                        <span class="stat-number">200+</span>
+                        <span class="stat-label">学习资源</span>
+                    </div>
+                    <div class="stat-item">
+                        <span class="stat-number">50+</span>
+                        <span class="stat-label">开源项目</span>
+                    </div>
+                    <div class="stat-item">
+                        <span class="stat-number">30+</span>
+                        <span class="stat-label">实用工具</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- 快速导航 -->
+        <section class="quick-nav">
+            <div class="container">
+                <h2 class="section-title">快速导航</h2>
+                <div class="nav-grid">
+                    <div class="nav-card" onclick="scrollToSection('docs')">
+                        <div class="card-icon">📚</div>
+                        <h3>官方文档</h3>
+                        <p>Go官方文档、标准库、语言规范</p>
+                    </div>
+                    <div class="nav-card" onclick="scrollToSection('tutorials')">
+                        <div class="card-icon">🎓</div>
+                        <h3>教程学习</h3>
+                        <p>从入门到精通的学习教程</p>
+                    </div>
+                    <div class="nav-card" onclick="scrollToSection('tools')">
+                        <div class="card-icon">🛠️</div>
+                        <h3>开发工具</h3>
+                        <p>IDE、插件、在线工具等</p>
+                    </div>
+                    <div class="nav-card" onclick="scrollToSection('community')">
+                        <div class="card-icon">👥</div>
+                        <h3>社区论坛</h3>
+                        <p>技术交流、问答社区</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- 官方文档 -->
+        <section id="docs" class="content-section">
+            <div class="container">
+                <h2 class="section-title">📚 官方文档</h2>
+                <div class="resource-grid">
+                    <div class="resource-category">
+                        <h3 class="category-title">核心文档</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://golang.org/" target="_blank">Go官方网站</a> - 官方主站</li>
+                            <li><a href="https://go-zh.org/" target="_blank">Go中文官网</a> - 中文官方站点</li>
+                            <li><a href="https://golang.org/doc/" target="_blank">Go Documentation</a> - 官方文档</li>
+                            <li><a href="https://pkg.go.dev/" target="_blank">Go Packages</a> - 包文档</li>
+                            <li><a href="https://golang.org/ref/spec" target="_blank">Language Specification</a> - 语言规范</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">标准库</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://pkg.go.dev/std" target="_blank">Standard Library</a> - 标准库文档</li>
+                            <li><a href="http://cngolib.com/" target="_blank">Go标准库中文</a> - 中文标准库</li>
+                            <li><a href="https://golang.org/pkg/" target="_blank">Package Documentation</a> - 包文档索引</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">学习指南</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://tour.golang.org/" target="_blank">A Tour of Go</a> - 官方入门教程</li>
+                            <li><a href="https://tour.go-zh.org/" target="_blank">Go指南中文版</a> - 中文版教程</li>
+                            <li><a href="https://golang.org/doc/effective_go.html" target="_blank">Effective Go</a> - 编写规范</li>
+                            <li><a href="https://golang.org/doc/code.html" target="_blank">How to Write Go Code</a> - 代码组织</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- 教程学习 -->
+        <section id="tutorials" class="content-section">
+            <div class="container">
+                <h2 class="section-title">🎓 教程学习</h2>
+                <div class="resource-grid">
+                    <div class="resource-category">
+                        <h3 class="category-title">入门教程</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://www.topgoer.cn/" target="_blank">地鼠文档</a> - Go语言中文学习网站</li>
+                            <li><a href="https://studygolang.com/" target="_blank">Go语言中文网</a> - 国内知名Go社区</li>
+                            <li><a href="https://www.liwenzhou.com/posts/Go/golang-menu/" target="_blank">李文周的博客</a> - 系统性Go教程</li>
+                            <li><a href="https://github.com/unknwon/the-way-to-go_ZH_CN" target="_blank">Go入门指南</a> - 经典入门书籍</li>
+                            <li><a href="https://github.com/astaxie/build-web-application-with-golang" target="_blank">Go Web编程</a> - Web开发教程</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">进阶学习</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://draveness.me/golang/" target="_blank">Go语言设计与实现</a> - 深度剖析</li>
+                            <li><a href="https://golang.design/under-the-hood/" target="_blank">Go语言原本</a> - 源码解析</li>
+                            <li><a href="https://geektutu.com/" target="_blank">极客兔兔</a> - 7天系列教程</li>
+                            <li><a href="https://github.com/chai2010/advanced-go-programming-book" target="_blank">Go语言高级编程</a> - 进阶指南</li>
+                            <li><a href="https://golang3.eddycjy.com/" target="_blank">煎鱼的Go专栏</a> - 实战经验分享</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">视频教程</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://www.bilibili.com/video/BV1gf4y1r79E" target="_blank">Go语言基础教程</a> - B站入门视频</li>
+                            <li><a href="https://www.youtube.com/c/justforfunc" target="_blank">JustForFunc</a> - YouTube Go频道</li>
+                            <li><a href="https://talkgo.org/" target="_blank">Go夜读</a> - 技术分享</li>
+                            <li><a href="https://www.imooc.com/learn/345" target="_blank">Go语言第一课</a> - 慕课网</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- 开发工具 -->
+        <section id="tools" class="content-section">
+            <div class="container">
+                <h2 class="section-title">🛠️ 开发工具</h2>
+                <div class="resource-grid">
+                    <div class="resource-category">
+                        <h3 class="category-title">IDE编辑器</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://www.jetbrains.com/go/" target="_blank">GoLand</a> - JetBrains专业IDE</li>
+                            <li><a href="https://code.visualstudio.com/" target="_blank">VS Code</a> - 微软开发的编辑器</li>
+                            <li><a href="http://liteide.org/" target="_blank">LiteIDE</a> - 轻量级Go IDE</li>
+                            <li><a href="https://atom.io/" target="_blank">Atom</a> - GitHub开发的编辑器</li>
+                            <li><a href="https://www.vim.org/" target="_blank">Vim</a> - 经典文本编辑器</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">在线工具</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://play.golang.org/" target="_blank">Go Playground</a> - 在线运行Go代码</li>
+                            <li><a href="https://mholt.github.io/json-to-go/" target="_blank">JSON-to-Go</a> - JSON转Go结构体</li>
+                            <li><a href="https://regex101.com/" target="_blank">Regex101</a> - 正则表达式测试</li>
+                            <li><a href="https://goreportcard.com/" target="_blank">Go Report Card</a> - 代码质量检测</li>
+                            <li><a href="https://gocover.io/" target="_blank">Gocover.io</a> - 测试覆盖率</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">开发工具</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://github.com/golangci/golangci-lint" target="_blank">golangci-lint</a> - 代码检查工具</li>
+                            <li><a href="https://github.com/cosmtrek/air" target="_blank">Air</a> - 热重载工具</li>
+                            <li><a href="https://github.com/swaggo/swag" target="_blank">Swag</a> - API文档生成</li>
+                            <li><a href="https://github.com/golang-migrate/migrate" target="_blank">migrate</a> - 数据库迁移工具</li>
+                            <li><a href="https://github.com/goreleaser/goreleaser" target="_blank">GoReleaser</a> - 发布工具</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- 社区论坛 -->
+        <section id="community" class="content-section">
+            <div class="container">
+                <h2 class="section-title">👥 社区论坛</h2>
+                <div class="resource-grid">
+                    <div class="resource-category">
+                        <h3 class="category-title">中文社区</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://studygolang.com/" target="_blank">Go语言中文网</a> - 最大的中文Go社区</li>
+                            <li><a href="https://gocn.vip/" target="_blank">GoCN</a> - Go中国技术社区</li>
+                            <li><a href="https://www.golangtc.com/" target="_blank">Golang中国</a> - Go语言社区</li>
+                            <li><a href="https://learnku.com/go" target="_blank">LearnKu Go社区</a> - 学习交流平台</li>
+                            <li><a href="https://segmentfault.com/t/golang" target="_blank">SegmentFault Go</a> - 技术问答</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">国际社区</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://www.reddit.com/r/golang/" target="_blank">Reddit r/golang</a> - Go语言讨论区</li>
+                            <li><a href="https://stackoverflow.com/questions/tagged/go" target="_blank">Stack Overflow</a> - 技术问答</li>
+                            <li><a href="https://gophers.slack.com/" target="_blank">Gophers Slack</a> - Slack讨论组</li>
+                            <li><a href="https://forum.golangbridge.org/" target="_blank">Go Forum</a> - 官方论坛</li>
+                            <li><a href="https://groups.google.com/g/golang-nuts" target="_blank">golang-nuts</a> - 邮件列表</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">技术博客</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://blog.golang.org/" target="_blank">Go官方博客</a> - 官方技术博客</li>
+                            <li><a href="https://dave.cheney.net/" target="_blank">Dave Cheney</a> - Go核心开发者博客</li>
+                            <li><a href="https://rakyll.org/" target="_blank">JBD</a> - Google Go团队成员</li>
+                            <li><a href="https://www.ardanlabs.com/blog/" target="_blank">Ardan Labs</a> - Go培训机构博客</li>
+                            <li><a href="https://golangweekly.com/" target="_blank">Golang Weekly</a> - 周刊</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- 开源项目 -->
+        <section id="projects" class="content-section">
+            <div class="container">
+                <h2 class="section-title">🚀 优秀项目</h2>
+                <div class="resource-grid">
+                    <div class="resource-category">
+                        <h3 class="category-title">Web框架</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://github.com/gin-gonic/gin" target="_blank">Gin</a> - 高性能HTTP Web框架</li>
+                            <li><a href="https://github.com/beego/beego" target="_blank">Beego</a> - 企业级Web框架</li>
+                            <li><a href="https://github.com/labstack/echo" target="_blank">Echo</a> - 高性能极简框架</li>
+                            <li><a href="https://github.com/gorilla/mux" target="_blank">Gorilla Mux</a> - 强大的路由器</li>
+                            <li><a href="https://github.com/go-chi/chi" target="_blank">Chi</a> - 轻量级路由器</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">数据库ORM</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://github.com/go-gorm/gorm" target="_blank">GORM</a> - 功能丰富的ORM库</li>
+                            <li><a href="https://github.com/go-xorm/xorm" target="_blank">XORM</a> - 简单强大的ORM</li>
+                            <li><a href="https://github.com/jmoiron/sqlx" target="_blank">SQLx</a> - 扩展database/sql</li>
+                            <li><a href="https://github.com/upper/db" target="_blank">Upper.io</a> - 数据访问层</li>
+                            <li><a href="https://github.com/volatiletech/sqlboiler" target="_blank">SQLBoiler</a> - 代码生成ORM</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">微服务框架</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://github.com/go-kratos/kratos" target="_blank">Kratos</a> - B站开源微服务框架</li>
+                            <li><a href="https://github.com/zeromicro/go-zero" target="_blank">go-zero</a> - 云原生微服务框架</li>
+                            <li><a href="https://github.com/go-kit/kit" target="_blank">Go Kit</a> - 微服务工具包</li>
+                            <li><a href="https://github.com/micro/micro" target="_blank">Micro</a> - 微服务开发框架</li>
+                            <li><a href="https://github.com/go-chassis/go-chassis" target="_blank">Go Chassis</a> - 华为微服务框架</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- 面试题库 -->
+        <section class="content-section">
+            <div class="container">
+                <h2 class="section-title">📝 面试题库</h2>
+                <div class="resource-grid">
+                    <div class="resource-category">
+                        <h3 class="category-title">面试准备</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://www.topgoer.cn/docs/gomianshiti/gomianshiti-1cpgf5f10q2q0" target="_blank">Go面试题集</a> - 地鼠文档面试题</li>
+                            <li><a href="https://github.com/qcrao/Go-Questions" target="_blank">Go Questions</a> - Go语言知识图谱</li>
+                            <li><a href="https://github.com/lifei6671/interview-go" target="_blank">Interview Go</a> - Go面试题集合</li>
+                            <li><a href="https://golang.design/go-questions/" target="_blank">Go程序员面试笔试宝典</a> - 面试宝典</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">学习路线</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://github.com/yangwenmai/learning-golang" target="_blank">Learning Golang</a> - 学习资源整理</li>
+                            <li><a href="https://github.com/yongxinz/gopher" target="_blank">Gopher学习路线</a> - 完整学习路径</li>
+                            <li><a href="https://roadmap.sh/golang" target="_blank">Go Developer Roadmap</a> - 开发者路线图</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- 页脚 -->
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h3>关于本站</h3>
+                    <p>Gopher Navigator 致力于收集整理最全面、最实用的Go语言学习资源，助力开发者更好地学习和使用Go语言。</p>
+                </div>
+                <div class="footer-section">
+                    <h3>快速链接</h3>
+                    <ul>
+                        <li><a href="https://golang.org/">Go官网</a></li>
+                        <li><a href="https://pkg.go.dev/">包文档</a></li>
+                        <li><a href="https://play.golang.org/">在线运行</a></li>
+                        <li><a href="https://blog.golang.org/">官方博客</a></li>
+                    </ul>
+                </div>
+                <div class="footer-section">
+                    <h3>联系我们</h3>
+                    <p>如果您有好的Go语言资源推荐，欢迎通过GitHub Issues提交。</p>
+                    <a href="https://github.com/yourusername/gopher-navigator" target="_blank" class="github-link">
+                        GitHub仓库
+                    </a>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2024 Gopher Navigator. 本站收录的资源均来自互联网，版权归原作者所有。</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="js/script.js"></script>
+</body>
+</html>

--- a/js/script.js
+++ b/js/script.js
@@ -1,0 +1,478 @@
+// 等待DOM加载完成
+document.addEventListener('DOMContentLoaded', function() {
+    
+    // 平滑滚动到指定部分
+    function scrollToSection(sectionId) {
+        const section = document.getElementById(sectionId);
+        if (section) {
+            section.scrollIntoView({
+                behavior: 'smooth',
+                block: 'start'
+            });
+        }
+    }
+
+    // 为快速导航卡片添加点击事件
+    const navCards = document.querySelectorAll('.nav-card');
+    navCards.forEach(card => {
+        card.addEventListener('click', function() {
+            const onclick = this.getAttribute('onclick');
+            if (onclick) {
+                const sectionId = onclick.match(/scrollToSection\('(.+)'\)/)[1];
+                scrollToSection(sectionId);
+            }
+        });
+    });
+
+    // 导航链接平滑滚动
+    const navLinks = document.querySelectorAll('.nav-link[href^="#"]');
+    navLinks.forEach(link => {
+        link.addEventListener('click', function(e) {
+            e.preventDefault();
+            const targetId = this.getAttribute('href').substring(1);
+            scrollToSection(targetId);
+        });
+    });
+
+    // 页面滚动时的导航高亮
+    function updateActiveNavLink() {
+        const sections = document.querySelectorAll('section[id]');
+        const navLinks = document.querySelectorAll('.nav-link[href^="#"]');
+        
+        let currentSection = '';
+        const scrollPos = window.scrollY + 100; // 偏移量
+
+        sections.forEach(section => {
+            const sectionTop = section.offsetTop;
+            const sectionHeight = section.offsetHeight;
+            
+            if (scrollPos >= sectionTop && scrollPos < sectionTop + sectionHeight) {
+                currentSection = section.getAttribute('id');
+            }
+        });
+
+        navLinks.forEach(link => {
+            link.classList.remove('active');
+            if (link.getAttribute('href') === '#' + currentSection) {
+                link.classList.add('active');
+            }
+        });
+    }
+
+    // 监听滚动事件
+    window.addEventListener('scroll', throttle(updateActiveNavLink, 100));
+
+    // 节流函数
+    function throttle(func, wait) {
+        let timeout;
+        return function executedFunction(...args) {
+            const later = () => {
+                clearTimeout(timeout);
+                func(...args);
+            };
+            clearTimeout(timeout);
+            timeout = setTimeout(later, wait);
+        };
+    }
+
+    // 搜索功能
+    function createSearchFeature() {
+        // 创建搜索框
+        const searchContainer = document.createElement('div');
+        searchContainer.className = 'search-container';
+        searchContainer.innerHTML = `
+            <input type="text" id="searchInput" placeholder="搜索资源..." class="search-input">
+            <div id="searchResults" class="search-results"></div>
+        `;
+
+        // 将搜索框插入到快速导航区域
+        const quickNav = document.querySelector('.quick-nav .container');
+        if (quickNav) {
+            quickNav.insertBefore(searchContainer, quickNav.firstChild);
+        }
+
+        // 搜索功能实现
+        const searchInput = document.getElementById('searchInput');
+        const searchResults = document.getElementById('searchResults');
+
+        if (searchInput) {
+            searchInput.addEventListener('input', function() {
+                const query = this.value.toLowerCase().trim();
+                
+                if (query.length < 2) {
+                    searchResults.innerHTML = '';
+                    searchResults.style.display = 'none';
+                    return;
+                }
+
+                // 搜索所有链接
+                const allLinks = document.querySelectorAll('.resource-list a');
+                const results = [];
+
+                allLinks.forEach(link => {
+                    const text = link.textContent.toLowerCase();
+                    if (text.includes(query)) {
+                        results.push({
+                            title: link.textContent,
+                            url: link.href,
+                            category: link.closest('.resource-category')?.querySelector('.category-title')?.textContent || '未分类'
+                        });
+                    }
+                });
+
+                // 显示搜索结果
+                if (results.length > 0) {
+                    searchResults.innerHTML = results.slice(0, 10).map(result => `
+                        <div class="search-result-item">
+                            <a href="${result.url}" target="_blank">
+                                <div class="result-title">${result.title}</div>
+                                <div class="result-category">${result.category}</div>
+                            </a>
+                        </div>
+                    `).join('');
+                    searchResults.style.display = 'block';
+                } else {
+                    searchResults.innerHTML = '<div class="no-results">未找到相关资源</div>';
+                    searchResults.style.display = 'block';
+                }
+            });
+
+            // 点击外部区域隐藏搜索结果
+            document.addEventListener('click', function(e) {
+                if (!searchContainer.contains(e.target)) {
+                    searchResults.style.display = 'none';
+                }
+            });
+        }
+    }
+
+    // 统计功能
+    function updateStats() {
+        const resourceLinks = document.querySelectorAll('.resource-list a').length;
+        const categories = document.querySelectorAll('.resource-category').length;
+        const sections = document.querySelectorAll('.content-section').length;
+
+        // 更新统计数字
+        const statNumbers = document.querySelectorAll('.stat-number');
+        if (statNumbers.length >= 3) {
+            statNumbers[0].textContent = resourceLinks + '+';
+            statNumbers[1].textContent = categories + '+';
+            statNumbers[2].textContent = sections + '+';
+        }
+    }
+
+    // 动画效果
+    function addAnimations() {
+        // 创建 Intersection Observer
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('animate-in');
+                }
+            });
+        }, {
+            threshold: 0.1,
+            rootMargin: '0px 0px -50px 0px'
+        });
+
+        // 观察所有需要动画的元素
+        const animateElements = document.querySelectorAll('.resource-category, .nav-card');
+        animateElements.forEach(el => {
+            observer.observe(el);
+        });
+    }
+
+    // 返回顶部按钮
+    function createBackToTopButton() {
+        const backToTop = document.createElement('button');
+        backToTop.innerHTML = '↑';
+        backToTop.className = 'back-to-top';
+        backToTop.setAttribute('aria-label', '返回顶部');
+        
+        backToTop.addEventListener('click', () => {
+            window.scrollTo({
+                top: 0,
+                behavior: 'smooth'
+            });
+        });
+
+        document.body.appendChild(backToTop);
+
+        // 控制按钮显示/隐藏
+        window.addEventListener('scroll', () => {
+            if (window.scrollY > 500) {
+                backToTop.classList.add('visible');
+            } else {
+                backToTop.classList.remove('visible');
+            }
+        });
+    }
+
+    // 主题切换功能
+    function createThemeToggle() {
+        const themeToggle = document.createElement('button');
+        themeToggle.innerHTML = '🌙';
+        themeToggle.className = 'theme-toggle';
+        themeToggle.setAttribute('aria-label', '切换主题');
+        
+        // 添加到导航栏
+        const navMenu = document.querySelector('.nav-menu');
+        if (navMenu) {
+            const themeItem = document.createElement('li');
+            themeItem.className = 'nav-item';
+            themeItem.appendChild(themeToggle);
+            navMenu.appendChild(themeItem);
+        }
+
+        // 检查本地存储的主题设置
+        const currentTheme = localStorage.getItem('theme');
+        if (currentTheme === 'dark') {
+            document.body.classList.add('dark-theme');
+            themeToggle.innerHTML = '☀️';
+        }
+
+        themeToggle.addEventListener('click', () => {
+            document.body.classList.toggle('dark-theme');
+            
+            if (document.body.classList.contains('dark-theme')) {
+                themeToggle.innerHTML = '☀️';
+                localStorage.setItem('theme', 'dark');
+            } else {
+                themeToggle.innerHTML = '🌙';
+                localStorage.setItem('theme', 'light');
+            }
+        });
+    }
+
+    // 访问统计
+    function trackVisits() {
+        let visits = localStorage.getItem('siteVisits') || 0;
+        visits = parseInt(visits) + 1;
+        localStorage.setItem('siteVisits', visits);
+        
+        console.log(`您是第 ${visits} 次访问本站`);
+    }
+
+    // 键盘快捷键
+    function setupKeyboardShortcuts() {
+        document.addEventListener('keydown', (e) => {
+            // Ctrl + K 或 Cmd + K 打开搜索
+            if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+                e.preventDefault();
+                const searchInput = document.getElementById('searchInput');
+                if (searchInput) {
+                    searchInput.focus();
+                }
+            }
+            
+            // ESC 关闭搜索结果
+            if (e.key === 'Escape') {
+                const searchResults = document.getElementById('searchResults');
+                if (searchResults) {
+                    searchResults.style.display = 'none';
+                }
+            }
+        });
+    }
+
+    // 初始化所有功能
+    function init() {
+        createSearchFeature();
+        updateStats();
+        addAnimations();
+        createBackToTopButton();
+        createThemeToggle();
+        trackVisits();
+        setupKeyboardShortcuts();
+        
+        // 初始化导航高亮
+        updateActiveNavLink();
+        
+        console.log('Gopher Navigator 已加载完成！');
+    }
+
+    // 执行初始化
+    init();
+
+    // 全局暴露scrollToSection函数
+    window.scrollToSection = scrollToSection;
+});
+
+// 添加额外的CSS样式
+const additionalStyles = `
+    .search-container {
+        margin-bottom: 2rem;
+        position: relative;
+        max-width: 500px;
+        margin: 0 auto 2rem;
+    }
+
+    .search-input {
+        width: 100%;
+        padding: 1rem;
+        border: 2px solid #e0e0e0;
+        border-radius: 8px;
+        font-size: 1rem;
+        outline: none;
+        transition: border-color 0.3s ease;
+    }
+
+    .search-input:focus {
+        border-color: #00ADD8;
+    }
+
+    .search-results {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        background: white;
+        border: 1px solid #e0e0e0;
+        border-radius: 8px;
+        box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+        max-height: 400px;
+        overflow-y: auto;
+        z-index: 1000;
+        display: none;
+    }
+
+    .search-result-item {
+        border-bottom: 1px solid #f0f0f0;
+    }
+
+    .search-result-item:last-child {
+        border-bottom: none;
+    }
+
+    .search-result-item a {
+        display: block;
+        padding: 1rem;
+        text-decoration: none;
+        color: #333;
+        transition: background-color 0.3s ease;
+    }
+
+    .search-result-item a:hover {
+        background-color: #f8f9fa;
+    }
+
+    .result-title {
+        font-weight: 600;
+        margin-bottom: 0.2rem;
+    }
+
+    .result-category {
+        font-size: 0.8rem;
+        color: #666;
+    }
+
+    .no-results {
+        padding: 1rem;
+        text-align: center;
+        color: #666;
+    }
+
+    .back-to-top {
+        position: fixed;
+        bottom: 20px;
+        right: 20px;
+        width: 50px;
+        height: 50px;
+        background: #00ADD8;
+        color: white;
+        border: none;
+        border-radius: 50%;
+        font-size: 1.2rem;
+        cursor: pointer;
+        opacity: 0;
+        visibility: hidden;
+        transition: all 0.3s ease;
+        z-index: 1000;
+    }
+
+    .back-to-top.visible {
+        opacity: 1;
+        visibility: visible;
+    }
+
+    .back-to-top:hover {
+        background: #0088a8;
+        transform: translateY(-2px);
+    }
+
+    .theme-toggle {
+        background: none;
+        border: none;
+        font-size: 1.2rem;
+        cursor: pointer;
+        padding: 0.5rem;
+        border-radius: 50%;
+        transition: background-color 0.3s ease;
+    }
+
+    .theme-toggle:hover {
+        background-color: rgba(0, 173, 216, 0.1);
+    }
+
+    .nav-link.active {
+        color: #00ADD8;
+    }
+
+    .nav-link.active::after {
+        width: 100%;
+    }
+
+    .animate-in {
+        animation: fadeInUp 0.6s ease-out;
+    }
+
+    .dark-theme {
+        background-color: #1a1a1a;
+        color: #e0e0e0;
+    }
+
+    .dark-theme .header {
+        background: #2d2d2d;
+    }
+
+    .dark-theme .nav-link {
+        color: #e0e0e0;
+    }
+
+    .dark-theme .search-input {
+        background: #2d2d2d;
+        color: #e0e0e0;
+        border-color: #404040;
+    }
+
+    .dark-theme .search-results {
+        background: #2d2d2d;
+        border-color: #404040;
+    }
+
+    .dark-theme .search-result-item a {
+        color: #e0e0e0;
+    }
+
+    .dark-theme .search-result-item a:hover {
+        background-color: #404040;
+    }
+
+    @media (max-width: 768px) {
+        .search-container {
+            margin: 0 1rem 2rem;
+        }
+        
+        .back-to-top {
+            bottom: 15px;
+            right: 15px;
+            width: 45px;
+            height: 45px;
+        }
+    }
+`;
+
+// 将额外样式添加到页面
+const styleSheet = document.createElement('style');
+styleSheet.textContent = additionalStyles;
+document.head.appendChild(styleSheet);

--- a/scraper/go_resources.json
+++ b/scraper/go_resources.json
@@ -1,0 +1,240 @@
+{
+  "official_docs": [
+    {
+      "name": "Go官方网站",
+      "url": "https://golang.org/",
+      "description": "Go语言官方网站"
+    },
+    {
+      "name": "Go中文官网",
+      "url": "https://go-zh.org/",
+      "description": "Go语言中文官方站点"
+    },
+    {
+      "name": "Go文档",
+      "url": "https://golang.org/doc/",
+      "description": "Go语言官方文档"
+    },
+    {
+      "name": "Go包文档",
+      "url": "https://pkg.go.dev/",
+      "description": "Go包和模块文档"
+    },
+    {
+      "name": "Go语言规范",
+      "url": "https://golang.org/ref/spec",
+      "description": "Go语言规范文档"
+    }
+  ],
+  "tutorials": [
+    {
+      "name": "地鼠文档",
+      "url": "https://www.topgoer.cn/",
+      "description": "Go语言中文学习网站"
+    },
+    {
+      "name": "Go语言中文网",
+      "url": "https://studygolang.com/",
+      "description": "国内知名Go社区"
+    },
+    {
+      "name": "李文周的博客",
+      "url": "https://www.liwenzhou.com/posts/Go/golang-menu/",
+      "description": "系统性Go教程"
+    },
+    {
+      "name": "Go入门指南",
+      "url": "https://github.com/unknwon/the-way-to-go_ZH_CN",
+      "description": "经典入门书籍"
+    },
+    {
+      "name": "Go Web编程",
+      "url": "https://github.com/astaxie/build-web-application-with-golang",
+      "description": "Web开发教程"
+    }
+  ],
+  "advanced": [
+    {
+      "name": "Go语言设计与实现",
+      "url": "https://draveness.me/golang/",
+      "description": "深度剖析Go语言"
+    },
+    {
+      "name": "Go语言原本",
+      "url": "https://golang.design/under-the-hood/",
+      "description": "Go语言源码解析"
+    },
+    {
+      "name": "极客兔兔",
+      "url": "https://geektutu.com/",
+      "description": "7天系列教程"
+    },
+    {
+      "name": "Go语言高级编程",
+      "url": "https://github.com/chai2010/advanced-go-programming-book",
+      "description": "Go语言进阶指南"
+    },
+    {
+      "name": "煎鱼的Go专栏",
+      "url": "https://golang3.eddycjy.com/",
+      "description": "实战经验分享"
+    }
+  ],
+  "frameworks": [
+    {
+      "name": "Gin",
+      "url": "https://github.com/gin-gonic/gin",
+      "description": "高性能HTTP Web框架"
+    },
+    {
+      "name": "Beego",
+      "url": "https://github.com/beego/beego",
+      "description": "企业级Web框架"
+    },
+    {
+      "name": "Echo",
+      "url": "https://github.com/labstack/echo",
+      "description": "高性能极简框架"
+    },
+    {
+      "name": "Gorilla Mux",
+      "url": "https://github.com/gorilla/mux",
+      "description": "强大的路由器"
+    },
+    {
+      "name": "Chi",
+      "url": "https://github.com/go-chi/chi",
+      "description": "轻量级路由器"
+    }
+  ],
+  "databases": [
+    {
+      "name": "GORM",
+      "url": "https://github.com/go-gorm/gorm",
+      "description": "功能丰富的ORM库"
+    },
+    {
+      "name": "XORM",
+      "url": "https://github.com/go-xorm/xorm",
+      "description": "简单强大的ORM"
+    },
+    {
+      "name": "SQLx",
+      "url": "https://github.com/jmoiron/sqlx",
+      "description": "扩展database/sql"
+    },
+    {
+      "name": "Upper.io",
+      "url": "https://github.com/upper/db",
+      "description": "数据访问层"
+    },
+    {
+      "name": "SQLBoiler",
+      "url": "https://github.com/volatiletech/sqlboiler",
+      "description": "代码生成ORM"
+    }
+  ],
+  "microservices": [
+    {
+      "name": "Kratos",
+      "url": "https://github.com/go-kratos/kratos",
+      "description": "B站开源微服务框架"
+    },
+    {
+      "name": "go-zero",
+      "url": "https://github.com/zeromicro/go-zero",
+      "description": "云原生微服务框架"
+    },
+    {
+      "name": "Go Kit",
+      "url": "https://github.com/go-kit/kit",
+      "description": "微服务工具包"
+    },
+    {
+      "name": "Micro",
+      "url": "https://github.com/micro/micro",
+      "description": "微服务开发框架"
+    },
+    {
+      "name": "Go Chassis",
+      "url": "https://github.com/go-chassis/go-chassis",
+      "description": "华为微服务框架"
+    }
+  ],
+  "tools": [
+    {
+      "name": "GoLand",
+      "url": "https://www.jetbrains.com/go/",
+      "description": "JetBrains专业IDE"
+    },
+    {
+      "name": "VS Code",
+      "url": "https://code.visualstudio.com/",
+      "description": "微软开发的编辑器"
+    },
+    {
+      "name": "LiteIDE",
+      "url": "http://liteide.org/",
+      "description": "轻量级Go IDE"
+    },
+    {
+      "name": "Go Playground",
+      "url": "https://play.golang.org/",
+      "description": "在线运行Go代码"
+    },
+    {
+      "name": "JSON-to-Go",
+      "url": "https://mholt.github.io/json-to-go/",
+      "description": "JSON转Go结构体"
+    }
+  ],
+  "communities": [
+    {
+      "name": "Go语言中文网",
+      "url": "https://studygolang.com/",
+      "description": "最大的中文Go社区"
+    },
+    {
+      "name": "GoCN",
+      "url": "https://gocn.vip/",
+      "description": "Go中国技术社区"
+    },
+    {
+      "name": "Golang中国",
+      "url": "https://www.golangtc.com/",
+      "description": "Go语言社区"
+    },
+    {
+      "name": "Reddit r/golang",
+      "url": "https://www.reddit.com/r/golang/",
+      "description": "Go语言讨论区"
+    },
+    {
+      "name": "Stack Overflow",
+      "url": "https://stackoverflow.com/questions/tagged/go",
+      "description": "技术问答"
+    }
+  ],
+  "interview": [
+    {
+      "name": "Go面试题集",
+      "url": "https://www.topgoer.cn/docs/gomianshiti/gomianshiti-1cpgf5f10q2q0",
+      "description": "地鼠文档面试题"
+    },
+    {
+      "name": "Go Questions",
+      "url": "https://github.com/qcrao/Go-Questions",
+      "description": "Go语言知识图谱"
+    },
+    {
+      "name": "Interview Go",
+      "url": "https://github.com/lifei6671/interview-go",
+      "description": "Go面试题集合"
+    },
+    {
+      "name": "Go程序员面试笔试宝典",
+      "url": "https://golang.design/go-questions/",
+      "description": "面试宝典"
+    }
+  ]
+}

--- a/scraper/go_resources_scraper.py
+++ b/scraper/go_resources_scraper.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Go语言资源爬虫
+用于从各大网站爬取Go语言相关的学习资源、项目和文档
+"""
+
+import requests
+from bs4 import BeautifulSoup
+import json
+import time
+import re
+from urllib.parse import urljoin, urlparse
+import logging
+
+# 配置日志
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+class GoResourceScraper:
+    def __init__(self):
+        self.session = requests.Session()
+        self.session.headers.update({
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+        })
+        self.resources = {
+            'official_docs': [],
+            'tutorials': [],
+            'books': [],
+            'tools': [],
+            'frameworks': [],
+            'libraries': [],
+            'blogs': [],
+            'communities': [],
+            'videos': [],
+            'projects': []
+        }
+
+    def scrape_github_awesome_go(self):
+        """爬取GitHub上的awesome-go项目"""
+        try:
+            logger.info("正在爬取 awesome-go...")
+            url = "https://raw.githubusercontent.com/avelino/awesome-go/master/README.md"
+            response = self.session.get(url, timeout=10)
+            response.raise_for_status()
+            
+            content = response.text
+            
+            # 解析Markdown内容，提取链接
+            links = re.findall(r'\[([^\]]+)\]\(([^)]+)\)', content)
+            
+            for title, link in links:
+                if 'github.com' in link:
+                    self.resources['projects'].append({
+                        'name': title,
+                        'url': link,
+                        'description': '',
+                        'category': 'opensource'
+                    })
+            
+            logger.info(f"从 awesome-go 获取了 {len(self.resources['projects'])} 个项目")
+            
+        except Exception as e:
+            logger.error(f"爬取 awesome-go 失败: {e}")
+
+    def scrape_go_dev_resources(self):
+        """爬取Go官方和社区资源"""
+        official_resources = [
+            {
+                'name': 'Go官方网站',
+                'url': 'https://golang.org/',
+                'description': 'Go语言官方网站',
+                'category': 'official'
+            },
+            {
+                'name': 'Go文档',
+                'url': 'https://golang.org/doc/',
+                'description': 'Go语言官方文档',
+                'category': 'official'
+            },
+            {
+                'name': 'Go包管理',
+                'url': 'https://pkg.go.dev/',
+                'description': 'Go包和模块文档',
+                'category': 'official'
+            },
+            {
+                'name': 'Go Playground',
+                'url': 'https://play.golang.org/',
+                'description': '在线Go代码运行环境',
+                'category': 'tool'
+            },
+            {
+                'name': 'Go博客',
+                'url': 'https://blog.golang.org/',
+                'description': 'Go官方技术博客',
+                'category': 'blog'
+            }
+        ]
+        
+        self.resources['official_docs'].extend(official_resources)
+        logger.info(f"添加了 {len(official_resources)} 个官方资源")
+
+    def scrape_chinese_resources(self):
+        """添加中文Go语言资源"""
+        chinese_resources = [
+            {
+                'name': '地鼠文档',
+                'url': 'https://www.topgoer.cn/',
+                'description': 'Go语言中文学习网站',
+                'category': 'tutorial'
+            },
+            {
+                'name': 'Go语言中文网',
+                'url': 'https://studygolang.com/',
+                'description': '国内最大的Go语言社区',
+                'category': 'community'
+            },
+            {
+                'name': 'GoCN',
+                'url': 'https://gocn.vip/',
+                'description': 'Go中国技术社区',
+                'category': 'community'
+            },
+            {
+                'name': '李文周的博客',
+                'url': 'https://www.liwenzhou.com/posts/Go/golang-menu/',
+                'description': '系统性Go语言教程',
+                'category': 'tutorial'
+            },
+            {
+                'name': 'Go语言设计与实现',
+                'url': 'https://draveness.me/golang/',
+                'description': '深度解析Go语言实现原理',
+                'category': 'tutorial'
+            }
+        ]
+        
+        for resource in chinese_resources:
+            if resource['category'] == 'tutorial':
+                self.resources['tutorials'].append(resource)
+            elif resource['category'] == 'community':
+                self.resources['communities'].append(resource)
+        
+        logger.info(f"添加了 {len(chinese_resources)} 个中文资源")
+
+    def scrape_popular_frameworks(self):
+        """爬取流行的Go框架"""
+        frameworks = [
+            {
+                'name': 'Gin',
+                'url': 'https://github.com/gin-gonic/gin',
+                'description': '高性能HTTP Web框架',
+                'category': 'web'
+            },
+            {
+                'name': 'Echo',
+                'url': 'https://github.com/labstack/echo',
+                'description': '高性能、极简的Go Web框架',
+                'category': 'web'
+            },
+            {
+                'name': 'Beego',
+                'url': 'https://github.com/beego/beego',
+                'description': '用于快速开发的企业级应用框架',
+                'category': 'web'
+            },
+            {
+                'name': 'GORM',
+                'url': 'https://github.com/go-gorm/gorm',
+                'description': '功能丰富的Go ORM库',
+                'category': 'database'
+            },
+            {
+                'name': 'go-zero',
+                'url': 'https://github.com/zeromicro/go-zero',
+                'description': '云原生Go微服务框架',
+                'category': 'microservice'
+            }
+        ]
+        
+        self.resources['frameworks'].extend(frameworks)
+        logger.info(f"添加了 {len(frameworks)} 个框架")
+
+    def scrape_learning_books(self):
+        """收集Go学习书籍"""
+        books = [
+            {
+                'name': 'Go程序设计语言',
+                'url': 'https://github.com/golang-china/gopl-zh',
+                'description': 'Go语言圣经中文版',
+                'category': 'book'
+            },
+            {
+                'name': 'Go入门指南',
+                'url': 'https://github.com/unknwon/the-way-to-go_ZH_CN',
+                'description': '《The Way to Go》中文版',
+                'category': 'book'
+            },
+            {
+                'name': 'Go Web编程',
+                'url': 'https://github.com/astaxie/build-web-application-with-golang',
+                'description': 'Go Web开发教程',
+                'category': 'book'
+            },
+            {
+                'name': 'Go语言高级编程',
+                'url': 'https://github.com/chai2010/advanced-go-programming-book',
+                'description': 'Go语言进阶教程',
+                'category': 'book'
+            }
+        ]
+        
+        self.resources['books'].extend(books)
+        logger.info(f"添加了 {len(books)} 本书籍")
+
+    def scrape_dev_tools(self):
+        """收集Go开发工具"""
+        tools = [
+            {
+                'name': 'GoLand',
+                'url': 'https://www.jetbrains.com/go/',
+                'description': 'JetBrains出品的Go IDE',
+                'category': 'ide'
+            },
+            {
+                'name': 'VS Code',
+                'url': 'https://code.visualstudio.com/',
+                'description': '微软出品的轻量级编辑器',
+                'category': 'editor'
+            },
+            {
+                'name': 'golangci-lint',
+                'url': 'https://github.com/golangci/golangci-lint',
+                'description': 'Go代码检查工具',
+                'category': 'linter'
+            },
+            {
+                'name': 'air',
+                'url': 'https://github.com/cosmtrek/air',
+                'description': 'Go程序热重载工具',
+                'category': 'development'
+            }
+        ]
+        
+        self.resources['tools'].extend(tools)
+        logger.info(f"添加了 {len(tools)} 个工具")
+
+    def validate_urls(self):
+        """验证URL的有效性"""
+        logger.info("开始验证URL...")
+        for category, items in self.resources.items():
+            valid_items = []
+            for item in items:
+                try:
+                    response = self.session.head(item['url'], timeout=5)
+                    if response.status_code < 400:
+                        valid_items.append(item)
+                    else:
+                        logger.warning(f"无效URL: {item['url']} (状态码: {response.status_code})")
+                except Exception as e:
+                    logger.warning(f"URL验证失败: {item['url']} - {e}")
+                time.sleep(0.5)  # 避免请求过于频繁
+            
+            self.resources[category] = valid_items
+            logger.info(f"{category}: 保留 {len(valid_items)}/{len(items)} 个有效资源")
+
+    def export_to_json(self, filename='go_resources.json'):
+        """导出资源到JSON文件"""
+        try:
+            with open(filename, 'w', encoding='utf-8') as f:
+                json.dump(self.resources, f, ensure_ascii=False, indent=2)
+            logger.info(f"资源已导出到 {filename}")
+        except Exception as e:
+            logger.error(f"导出失败: {e}")
+
+    def generate_html_snippet(self):
+        """生成HTML代码片段"""
+        html_snippets = []
+        
+        for category, items in self.resources.items():
+            if not items:
+                continue
+                
+            category_name = {
+                'official_docs': '官方文档',
+                'tutorials': '教程学习',
+                'books': '学习书籍',
+                'tools': '开发工具',
+                'frameworks': 'Web框架',
+                'libraries': '实用库',
+                'blogs': '技术博客',
+                'communities': '社区论坛',
+                'videos': '视频教程',
+                'projects': '开源项目'
+            }.get(category, category)
+            
+            html = f"""
+                    <div class="resource-category">
+                        <h3 class="category-title">{category_name}</h3>
+                        <ul class="resource-list">
+"""
+            
+            for item in items[:10]:  # 限制每个分类最多10个
+                description = item.get('description', '')
+                if description:
+                    description = f" - {description}"
+                html += f'                            <li><a href="{item["url"]}" target="_blank">{item["name"]}</a>{description}</li>\n'
+            
+            html += """                        </ul>
+                    </div>"""
+            
+            html_snippets.append(html)
+        
+        # 保存HTML片段到文件
+        with open('html_snippets.txt', 'w', encoding='utf-8') as f:
+            f.write('\n'.join(html_snippets))
+        
+        logger.info("HTML代码片段已生成到 html_snippets.txt")
+
+    def run(self):
+        """运行爬虫"""
+        logger.info("开始爬取Go语言资源...")
+        
+        # 执行各种爬取任务
+        self.scrape_go_dev_resources()
+        self.scrape_chinese_resources()
+        self.scrape_popular_frameworks()
+        self.scrape_learning_books()
+        self.scrape_dev_tools()
+        
+        # 可选：爬取GitHub awesome-go（比较慢）
+        # self.scrape_github_awesome_go()
+        
+        # 验证URL（可选，比较慢）
+        # self.validate_urls()
+        
+        # 导出结果
+        self.export_to_json()
+        self.generate_html_snippet()
+        
+        total_resources = sum(len(items) for items in self.resources.values())
+        logger.info(f"爬取完成！总共收集了 {total_resources} 个资源")
+
+def main():
+    scraper = GoResourceScraper()
+    scraper.run()
+
+if __name__ == "__main__":
+    main()

--- a/scraper/html_sections.txt
+++ b/scraper/html_sections.txt
@@ -1,0 +1,89 @@
+                    <div class="resource-category">
+                        <h3 class="category-title">官方文档</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://golang.org/" target="_blank">Go官方网站</a> - Go语言官方网站</li>
+                            <li><a href="https://go-zh.org/" target="_blank">Go中文官网</a> - Go语言中文官方站点</li>
+                            <li><a href="https://golang.org/doc/" target="_blank">Go文档</a> - Go语言官方文档</li>
+                            <li><a href="https://pkg.go.dev/" target="_blank">Go包文档</a> - Go包和模块文档</li>
+                            <li><a href="https://golang.org/ref/spec" target="_blank">Go语言规范</a> - Go语言规范文档</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">入门教程</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://www.topgoer.cn/" target="_blank">地鼠文档</a> - Go语言中文学习网站</li>
+                            <li><a href="https://studygolang.com/" target="_blank">Go语言中文网</a> - 国内知名Go社区</li>
+                            <li><a href="https://www.liwenzhou.com/posts/Go/golang-menu/" target="_blank">李文周的博客</a> - 系统性Go教程</li>
+                            <li><a href="https://github.com/unknwon/the-way-to-go_ZH_CN" target="_blank">Go入门指南</a> - 经典入门书籍</li>
+                            <li><a href="https://github.com/astaxie/build-web-application-with-golang" target="_blank">Go Web编程</a> - Web开发教程</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">进阶学习</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://draveness.me/golang/" target="_blank">Go语言设计与实现</a> - 深度剖析Go语言</li>
+                            <li><a href="https://golang.design/under-the-hood/" target="_blank">Go语言原本</a> - Go语言源码解析</li>
+                            <li><a href="https://geektutu.com/" target="_blank">极客兔兔</a> - 7天系列教程</li>
+                            <li><a href="https://github.com/chai2010/advanced-go-programming-book" target="_blank">Go语言高级编程</a> - Go语言进阶指南</li>
+                            <li><a href="https://golang3.eddycjy.com/" target="_blank">煎鱼的Go专栏</a> - 实战经验分享</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">Web框架</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://github.com/gin-gonic/gin" target="_blank">Gin</a> - 高性能HTTP Web框架</li>
+                            <li><a href="https://github.com/beego/beego" target="_blank">Beego</a> - 企业级Web框架</li>
+                            <li><a href="https://github.com/labstack/echo" target="_blank">Echo</a> - 高性能极简框架</li>
+                            <li><a href="https://github.com/gorilla/mux" target="_blank">Gorilla Mux</a> - 强大的路由器</li>
+                            <li><a href="https://github.com/go-chi/chi" target="_blank">Chi</a> - 轻量级路由器</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">数据库ORM</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://github.com/go-gorm/gorm" target="_blank">GORM</a> - 功能丰富的ORM库</li>
+                            <li><a href="https://github.com/go-xorm/xorm" target="_blank">XORM</a> - 简单强大的ORM</li>
+                            <li><a href="https://github.com/jmoiron/sqlx" target="_blank">SQLx</a> - 扩展database/sql</li>
+                            <li><a href="https://github.com/upper/db" target="_blank">Upper.io</a> - 数据访问层</li>
+                            <li><a href="https://github.com/volatiletech/sqlboiler" target="_blank">SQLBoiler</a> - 代码生成ORM</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">微服务框架</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://github.com/go-kratos/kratos" target="_blank">Kratos</a> - B站开源微服务框架</li>
+                            <li><a href="https://github.com/zeromicro/go-zero" target="_blank">go-zero</a> - 云原生微服务框架</li>
+                            <li><a href="https://github.com/go-kit/kit" target="_blank">Go Kit</a> - 微服务工具包</li>
+                            <li><a href="https://github.com/micro/micro" target="_blank">Micro</a> - 微服务开发框架</li>
+                            <li><a href="https://github.com/go-chassis/go-chassis" target="_blank">Go Chassis</a> - 华为微服务框架</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">开发工具</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://www.jetbrains.com/go/" target="_blank">GoLand</a> - JetBrains专业IDE</li>
+                            <li><a href="https://code.visualstudio.com/" target="_blank">VS Code</a> - 微软开发的编辑器</li>
+                            <li><a href="http://liteide.org/" target="_blank">LiteIDE</a> - 轻量级Go IDE</li>
+                            <li><a href="https://play.golang.org/" target="_blank">Go Playground</a> - 在线运行Go代码</li>
+                            <li><a href="https://mholt.github.io/json-to-go/" target="_blank">JSON-to-Go</a> - JSON转Go结构体</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">社区论坛</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://studygolang.com/" target="_blank">Go语言中文网</a> - 最大的中文Go社区</li>
+                            <li><a href="https://gocn.vip/" target="_blank">GoCN</a> - Go中国技术社区</li>
+                            <li><a href="https://www.golangtc.com/" target="_blank">Golang中国</a> - Go语言社区</li>
+                            <li><a href="https://www.reddit.com/r/golang/" target="_blank">Reddit r/golang</a> - Go语言讨论区</li>
+                            <li><a href="https://stackoverflow.com/questions/tagged/go" target="_blank">Stack Overflow</a> - 技术问答</li>
+                        </ul>
+                    </div>
+                    <div class="resource-category">
+                        <h3 class="category-title">面试准备</h3>
+                        <ul class="resource-list">
+                            <li><a href="https://www.topgoer.cn/docs/gomianshiti/gomianshiti-1cpgf5f10q2q0" target="_blank">Go面试题集</a> - 地鼠文档面试题</li>
+                            <li><a href="https://github.com/qcrao/Go-Questions" target="_blank">Go Questions</a> - Go语言知识图谱</li>
+                            <li><a href="https://github.com/lifei6671/interview-go" target="_blank">Interview Go</a> - Go面试题集合</li>
+                            <li><a href="https://golang.design/go-questions/" target="_blank">Go程序员面试笔试宝典</a> - 面试宝典</li>
+                        </ul>
+                    </div>

--- a/scraper/requirements.txt
+++ b/scraper/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.25.1
+beautifulsoup4>=4.9.3
+lxml>=4.6.3

--- a/scraper/simple_generator.py
+++ b/scraper/simple_generator.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+简化的Go语言资源生成器
+不需要外部依赖，直接生成常用的Go语言学习资源
+"""
+
+import json
+
+def generate_go_resources():
+    """生成Go语言学习资源"""
+    resources = {
+        "official_docs": [
+            {
+                "name": "Go官方网站",
+                "url": "https://golang.org/",
+                "description": "Go语言官方网站"
+            },
+            {
+                "name": "Go中文官网", 
+                "url": "https://go-zh.org/",
+                "description": "Go语言中文官方站点"
+            },
+            {
+                "name": "Go文档",
+                "url": "https://golang.org/doc/",
+                "description": "Go语言官方文档"
+            },
+            {
+                "name": "Go包文档",
+                "url": "https://pkg.go.dev/",
+                "description": "Go包和模块文档"
+            },
+            {
+                "name": "Go语言规范",
+                "url": "https://golang.org/ref/spec",
+                "description": "Go语言规范文档"
+            }
+        ],
+        "tutorials": [
+            {
+                "name": "地鼠文档",
+                "url": "https://www.topgoer.cn/",
+                "description": "Go语言中文学习网站"
+            },
+            {
+                "name": "Go语言中文网",
+                "url": "https://studygolang.com/",
+                "description": "国内知名Go社区"
+            },
+            {
+                "name": "李文周的博客",
+                "url": "https://www.liwenzhou.com/posts/Go/golang-menu/",
+                "description": "系统性Go教程"
+            },
+            {
+                "name": "Go入门指南",
+                "url": "https://github.com/unknwon/the-way-to-go_ZH_CN",
+                "description": "经典入门书籍"
+            },
+            {
+                "name": "Go Web编程",
+                "url": "https://github.com/astaxie/build-web-application-with-golang",
+                "description": "Web开发教程"
+            }
+        ],
+        "advanced": [
+            {
+                "name": "Go语言设计与实现",
+                "url": "https://draveness.me/golang/",
+                "description": "深度剖析Go语言"
+            },
+            {
+                "name": "Go语言原本",
+                "url": "https://golang.design/under-the-hood/",
+                "description": "Go语言源码解析"
+            },
+            {
+                "name": "极客兔兔",
+                "url": "https://geektutu.com/",
+                "description": "7天系列教程"
+            },
+            {
+                "name": "Go语言高级编程",
+                "url": "https://github.com/chai2010/advanced-go-programming-book",
+                "description": "Go语言进阶指南"
+            },
+            {
+                "name": "煎鱼的Go专栏",
+                "url": "https://golang3.eddycjy.com/",
+                "description": "实战经验分享"
+            }
+        ],
+        "frameworks": [
+            {
+                "name": "Gin",
+                "url": "https://github.com/gin-gonic/gin",
+                "description": "高性能HTTP Web框架"
+            },
+            {
+                "name": "Beego",
+                "url": "https://github.com/beego/beego",
+                "description": "企业级Web框架"
+            },
+            {
+                "name": "Echo",
+                "url": "https://github.com/labstack/echo",
+                "description": "高性能极简框架"
+            },
+            {
+                "name": "Gorilla Mux",
+                "url": "https://github.com/gorilla/mux",
+                "description": "强大的路由器"
+            },
+            {
+                "name": "Chi",
+                "url": "https://github.com/go-chi/chi",
+                "description": "轻量级路由器"
+            }
+        ],
+        "databases": [
+            {
+                "name": "GORM",
+                "url": "https://github.com/go-gorm/gorm",
+                "description": "功能丰富的ORM库"
+            },
+            {
+                "name": "XORM",
+                "url": "https://github.com/go-xorm/xorm",
+                "description": "简单强大的ORM"
+            },
+            {
+                "name": "SQLx",
+                "url": "https://github.com/jmoiron/sqlx",
+                "description": "扩展database/sql"
+            },
+            {
+                "name": "Upper.io",
+                "url": "https://github.com/upper/db",
+                "description": "数据访问层"
+            },
+            {
+                "name": "SQLBoiler",
+                "url": "https://github.com/volatiletech/sqlboiler",
+                "description": "代码生成ORM"
+            }
+        ],
+        "microservices": [
+            {
+                "name": "Kratos",
+                "url": "https://github.com/go-kratos/kratos",
+                "description": "B站开源微服务框架"
+            },
+            {
+                "name": "go-zero",
+                "url": "https://github.com/zeromicro/go-zero",
+                "description": "云原生微服务框架"
+            },
+            {
+                "name": "Go Kit",
+                "url": "https://github.com/go-kit/kit",
+                "description": "微服务工具包"
+            },
+            {
+                "name": "Micro",
+                "url": "https://github.com/micro/micro",
+                "description": "微服务开发框架"
+            },
+            {
+                "name": "Go Chassis",
+                "url": "https://github.com/go-chassis/go-chassis",
+                "description": "华为微服务框架"
+            }
+        ],
+        "tools": [
+            {
+                "name": "GoLand",
+                "url": "https://www.jetbrains.com/go/",
+                "description": "JetBrains专业IDE"
+            },
+            {
+                "name": "VS Code",
+                "url": "https://code.visualstudio.com/",
+                "description": "微软开发的编辑器"
+            },
+            {
+                "name": "LiteIDE",
+                "url": "http://liteide.org/",
+                "description": "轻量级Go IDE"
+            },
+            {
+                "name": "Go Playground",
+                "url": "https://play.golang.org/",
+                "description": "在线运行Go代码"
+            },
+            {
+                "name": "JSON-to-Go",
+                "url": "https://mholt.github.io/json-to-go/",
+                "description": "JSON转Go结构体"
+            }
+        ],
+        "communities": [
+            {
+                "name": "Go语言中文网",
+                "url": "https://studygolang.com/",
+                "description": "最大的中文Go社区"
+            },
+            {
+                "name": "GoCN",
+                "url": "https://gocn.vip/",
+                "description": "Go中国技术社区"
+            },
+            {
+                "name": "Golang中国",
+                "url": "https://www.golangtc.com/",
+                "description": "Go语言社区"
+            },
+            {
+                "name": "Reddit r/golang",
+                "url": "https://www.reddit.com/r/golang/",
+                "description": "Go语言讨论区"
+            },
+            {
+                "name": "Stack Overflow",
+                "url": "https://stackoverflow.com/questions/tagged/go",
+                "description": "技术问答"
+            }
+        ],
+        "interview": [
+            {
+                "name": "Go面试题集",
+                "url": "https://www.topgoer.cn/docs/gomianshiti/gomianshiti-1cpgf5f10q2q0",
+                "description": "地鼠文档面试题"
+            },
+            {
+                "name": "Go Questions",
+                "url": "https://github.com/qcrao/Go-Questions",
+                "description": "Go语言知识图谱"
+            },
+            {
+                "name": "Interview Go",
+                "url": "https://github.com/lifei6671/interview-go",
+                "description": "Go面试题集合"
+            },
+            {
+                "name": "Go程序员面试笔试宝典",
+                "url": "https://golang.design/go-questions/",
+                "description": "面试宝典"
+            }
+        ]
+    }
+    
+    return resources
+
+def generate_html_sections(resources):
+    """生成HTML代码段"""
+    category_names = {
+        "official_docs": "官方文档",
+        "tutorials": "入门教程", 
+        "advanced": "进阶学习",
+        "frameworks": "Web框架",
+        "databases": "数据库ORM",
+        "microservices": "微服务框架",
+        "tools": "开发工具",
+        "communities": "社区论坛",
+        "interview": "面试准备"
+    }
+    
+    html_sections = []
+    
+    for category, items in resources.items():
+        if not items:
+            continue
+            
+        category_title = category_names.get(category, category)
+        
+        html = f"""                    <div class="resource-category">
+                        <h3 class="category-title">{category_title}</h3>
+                        <ul class="resource-list">"""
+        
+        for item in items:
+            description = item.get('description', '')
+            if description:
+                description = f" - {description}"
+            html += f"""
+                            <li><a href="{item['url']}" target="_blank">{item['name']}</a>{description}</li>"""
+        
+        html += """
+                        </ul>
+                    </div>"""
+        
+        html_sections.append(html)
+    
+    return html_sections
+
+def main():
+    print("🚀 生成Go语言学习资源...")
+    
+    # 生成资源
+    resources = generate_go_resources()
+    
+    # 导出JSON
+    with open('go_resources.json', 'w', encoding='utf-8') as f:
+        json.dump(resources, f, ensure_ascii=False, indent=2)
+    
+    # 生成HTML片段
+    html_sections = generate_html_sections(resources)
+    with open('html_sections.txt', 'w', encoding='utf-8') as f:
+        f.write('\n'.join(html_sections))
+    
+    # 统计信息
+    total_resources = sum(len(items) for items in resources.values())
+    
+    print(f"✅ 生成完成！")
+    print(f"📊 统计信息：")
+    print(f"   - 总资源数: {total_resources}")
+    print(f"   - 分类数: {len(resources)}")
+    print(f"   - JSON文件: go_resources.json")
+    print(f"   - HTML片段: html_sections.txt")
+    
+    print(f"\n📂 分类详情：")
+    for category, items in resources.items():
+        print(f"   - {category}: {len(items)}个资源")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Gopher Navigator 部署脚本
+# 用于快速设置和部署 Go 语言导航站
+
+set -e
+
+echo "🚀 Gopher Navigator 部署脚本"
+echo "================================="
+
+# 检查当前目录
+if [ ! -f "index.html" ]; then
+    echo "❌ 错误：请在项目根目录运行此脚本"
+    exit 1
+fi
+
+# 检查是否在 Git 仓库中
+if [ ! -d ".git" ]; then
+    echo "📁 初始化 Git 仓库..."
+    git init
+    git add .
+    git commit -m "Initial commit: Gopher Navigator"
+fi
+
+# 检查是否有远程仓库
+if ! git remote | grep -q origin; then
+    echo "📡 请设置 GitHub 远程仓库："
+    echo "   git remote add origin https://github.com/yourusername/gopher-navigator.git"
+    echo "   然后重新运行此脚本"
+    exit 1
+fi
+
+# 检查 Python 环境（可选）
+if command -v python3 &> /dev/null; then
+    echo "🐍 检测到 Python3，你可以运行爬虫来更新资源"
+    echo "   cd scraper && pip install -r requirements.txt && python go_resources_scraper.py"
+fi
+
+# 推送到 GitHub
+echo "📤 推送到 GitHub..."
+git add .
+git commit -m "Update: $(date '+%Y-%m-%d %H:%M:%S')" || true
+git push origin main
+
+echo ""
+echo "✅ 部署完成！"
+echo ""
+echo "🌐 访问你的网站："
+echo "   https://$(git config --get remote.origin.url | sed 's/.*github.com\///g' | sed 's/\.git//g' | sed 's/\//\.github\.io\//g')"
+echo ""
+echo "📚 如果这是第一次部署，请："
+echo "   1. 访问 GitHub 仓库设置页面"
+echo "   2. 找到 'Pages' 设置"
+echo "   3. 选择 'main' 分支作为源"
+echo "   4. 等待几分钟让 GitHub Pages 生效"
+echo ""
+echo "🎉 享受你的 Go 语言导航站吧！"


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement a static Go language navigation site for GitHub Pages deployment.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR fulfills the user's request to create a static navigation site for Go language resources, inspired by `topgoer.cn`. It includes a complete HTML/CSS/JS frontend, pre-populated resource data, a Python scraper for content generation, and a GitHub Actions workflow for automated deployment to GitHub Pages.